### PR TITLE
Add gitlab.mesh

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -8,6 +8,7 @@ $TTL 3600
 dns   A     10.10.10.10
 ns    A     10.10.10.11
 ebook A     10.70.129.51
+gitlab A    10.70.123.5
 something A 1.1.1.1
 
 


### PR DESCRIPTION
I launched an on-mesh Gitlab instance at 10.70.123.5 that I'm willing to maintain. Not sure if grabbing gitlab.mesh is proper DNS etiquette or if you'd prefer something like gitlab.emerson.mesh - up to you.

Thanks for building & launching our .mesh DNS!