### PR TITLE
UNMS was renamed to UISP, let's go with the times!

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -12,7 +12,8 @@ dns   A     10.10.10.10
 ns    A     10.10.10.11
 ebook A     10.70.129.51
 something A 1.1.1.1
-unms	A 10.70.76.21
+unms	CNAME uisp
+uisp	A 10.70.76.21
 jimsblog A 10.70.140.70
 jim	A 10.70.140.70
 mail	A 10.70.140.70


### PR DESCRIPTION
Leaving unms.mesh in place with a CNAME to not make people's habits and configurations fail all of a sudden

Not strictly necessary, but the UISP/UNMS name change has been a bit confusing to some, I'm hoping this helps move us forward a bit.