### PR TITLE
Add tv.mesh to zone file

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -20,6 +20,7 @@ mail	A 10.70.140.70
 donuts A 10.70.73.29
 unifi A 10.70.95.63
 netbox A 10.70.90.135
+tv A 10.97.227.112
 
 ; Emerson
 gitlab A    10.70.123.5


### PR DESCRIPTION
Adding a hard link from the internal tv.mesh domain to the Grand Street - 1932 router.
Subject to change once 1932-core is removed!