### PR TITLE
Update mesh.zone

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -142,11 +142,11 @@ vernon.af24 A 10.70.253.28
 grand33.af24 A 10.70.253.29
 vernon.af60lr-2 A 10.70.253.30
 ph.af60lr A 10.70.253.31
-grand33.af60lr A 10.70.253.32
+grand33.af60lr-1 A 10.70.253.32
 parallel.af60lr A 10.70.253.33
 elliott.lbe A 10.70.253.34
 ccny.lbe A 10.70.253.35
-grand33.af60lr A 10.70.253.36
+grand33.af60lr-2 A 10.70.253.36
 navyyard.af60lr A 10.70.253.37
 sn10.fiber A 10.70.253.38
 grand34.fiber A 10.70.253.39


### PR DESCRIPTION
Corrected entry to have 2 distinct device names
grand33.af60lr-1 A 10.70.253.32
grand33.af60lr-2 A 10.70.253.36