### PR TITLE
Update mesh.zone

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -112,8 +112,8 @@ gnycmesh-375p-dns1.intpeer.sn1 A 10.70.252.9
 
 
 ; records for rDNS
-sn1.af24 A 10.70.253.0
-grand32.af24 A 10.70.253.1
+; sn1.af24 A 10.70.253.0
+; grand32.af24 A 10.70.253.1
 vernon.east A 10.70.253.2
 jefferson.lbe A 10.70.253.3
 sn3.af60lr A 10.70.253.4
@@ -128,8 +128,8 @@ grand32.lhg60-1 A 10.70.253.12
 grand33.lhg60 A 10.70.253.13
 guernsey.lbelr A 10.70.253.14
 grand32.lbelr A 10.70.253.15
-grand32.lhg60-2 A 10.70.253.16
-rivington.lgh60 A 10.70.253.17
+; grand32.lhg60-2 A 10.70.253.16
+; rivington.lgh60 A 10.70.253.17
 rivington.gbep A 10.70.253.18
 100ava.gbep A 10.70.253.19
 twobridge.lbe A 10.70.253.20
@@ -139,14 +139,25 @@ softsurplus.af24 A 10.70.253.23
 vernon.af60lr-1 A 10.70.253.26
 saratoga.af60lr A 10.70.253.27
 vernon.af24 A 10.70.253.28
-grand33.af24 A 10.70.253.29
-vernon.af60lr-2 A 10.70.253.30
+; grand33.af24 A 10.70.253.29
+; vernon.af60lr-2 A 10.70.253.30
 ph.af60lr A 10.70.253.31
-grand33.af60lr-1 A 10.70.253.32
-parallel.af60lr A 10.70.253.33
+; grand33.af60lr-1 A 10.70.253.32
+; parallel.af60lr A 10.70.253.33
 saratoga.lbe A 10.70.253.34
 cypress.lbe A 10.70.253.35
-grand33.af60lr-2 A 10.70.253.36
-navyyard.af60lr A 10.70.253.37
+; grand33.af60lr-2 A 10.70.253.36 
+; navyyard.af60lr A 10.70.253.37
 sn10.fiber A 10.70.253.38
 grand34.fiber A 10.70.253.39
+
+grand34.af60lr A 10.70.251.1
+parallel.af60lr A 10.70.251.2
+grand34.lhg60 A 10.70.251.5
+rivington.lhg60 A 10.70.251.6
+grand34.af60lr A 10.70.251.9
+navyyard.af60lr A 10.70.251.10
+grand34.af60lr A 10.70.251.13
+vernon.af60lr A 10.70.251.14
+sn1.af24 A 10.70.251.17
+grand34.af24 A 10.70.251.18


### PR DESCRIPTION
new ptp with grand 1934 (instead of 1932 and 1933) following the S16 moved to 1934-core