### PR TITLE
Change andrew.mesh NS record to point to public IP

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -46,7 +46,7 @@ petra A 10.70.90.87
 ipmi.petra A 10.70.90.89
 
 ; Andrew
-andrew-vpn-endpoint-router A 10.70.178.38
+andrew-vpn-endpoint-router A 54.161.165.190
 andrew NS andrew-vpn-endpoint-router
 
 ; Reserved as services are made


### PR DESCRIPTION
This was recommended by David Albert to resolve an issue I was having where my `*.andrew.mesh` records were working but `*.andrew.mesh.nycmesh.net` was not resolving.

Basically this issue is, currently public recursive resolvers can't access my authoritative DNS zone, since it's specified by a private IP. 
It would seem the concept of an NS record that points to a private IP doesn't make any sense in the context of public DNS lookups. Our current setup works because if you have private IPs in the public DNS tree, they have to be leaf nodes, otherwise you have problems.

This PR changes my NS record to point to the public address of my remote server. This does mean that these records will fail to resolve if the mesh looses connectivity to the internet, but since this is a VPN server anyway, that doesn't introduce any additional risk over what I have now.