### PR TITLE
Add public wiki IP to improve accessibility 

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -21,7 +21,7 @@ donuts A 10.70.73.29
 unifi A 10.70.95.63
 netbox A 10.70.90.135
 tv A 10.70.90.30
-wiki A 10.70.178.26
+wiki A 18.213.129.204
 
 ; Emerson
 gitlab A    10.70.123.5


### PR DESCRIPTION
Adds public wiki IP to improve accessibility.  

- Many potential wiki users who want to learn about Mesh do not have a VPN setup.  
- This change also allows Mesh volunteers to evaluate the wiki as an easier to edit docs replacement with search functionality etc.  