### PR TITLE
Add CNAME for devforms

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -68,7 +68,6 @@ grandsvc A 199.167.59.101
 ; k8s-infra
 db A 199.170.132.45
 *.db CNAME db
-*.svc CNAME db
 
 devdb A 199.170.132.46
 *.devdb CNAME devdb

--- a/mesh.zone
+++ b/mesh.zone
@@ -65,8 +65,11 @@ grandbox A 10.69.19.233
 grandsvc A 199.167.59.101
 *.grandsvc CNAME grandsvc
 
-; James
+; k8s-infra
 devdb A 199.170.132.46
+devforms CNAME devdb
+
+; James
 db A 199.170.132.45
 scan A 10.70.90.120
 wazuh A 10.70.90.75

--- a/mesh.zone
+++ b/mesh.zone
@@ -66,11 +66,16 @@ grandsvc A 199.167.59.101
 *.grandsvc CNAME grandsvc
 
 ; k8s-infra
+db A 199.170.132.45
+*.db CNAME db
+*.svc CNAME db
+
 devdb A 199.170.132.46
+*.devdb CNAME devdb
+*.dev CNAME devdb
 devforms CNAME devdb
 
 ; James
-db A 199.170.132.45
 scan A 10.70.90.120
 wazuh A 10.70.90.75
 jamesprojects A 10.70.90.53


### PR DESCRIPTION
Creates a CNAME for devforms to get traefik working and also make a new "section" in the .zone file for k8s-infra. We're gonna be adding like a million CNAMEs.