### PR TITLE
Add map CNAMEs

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -70,12 +70,17 @@ db A 199.170.132.45
 *.db CNAME db
 forms CNAME db
 wiki2 CNAME db
+adminmap CNAME db
+map CNAME db
 
+; k8s-infra dev
 devdb A 199.170.132.46
 *.devdb CNAME devdb
 *.dev CNAME devdb
 devforms CNAME devdb
 devwiki CNAME devdb
+devadminmap CNAME db
+devmap CNAME db
 
 ; James
 scan A 10.70.90.120


### PR DESCRIPTION
Add CNAMEs for admin and non-admin map services in dev and prod. This is to be used with meshdb.