### PR TITLE
Add meshdb domains under nycmesh.net

### DIFF
--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -249,14 +249,6 @@ resource "namedotcom_record" "record_monitoring_6041298" {
   answer      = "147.75.67.41"
 }
 
-# Line of Sight tool (DigitalOcean)
-resource "namedotcom_record" "record_los_6530453" {
-  domain_name = "nycmesh.net"
-  host        = "los"
-  record_type = "CNAME"
-  answer      = "line-of-sight.netlify.com"
-}
-
 # Redirects to https://github.com/meshcenter/mesh-api
 resource "namedotcom_record" "record_api_7081451" {
   domain_name = "nycmesh.net"
@@ -421,7 +413,7 @@ resource "namedotcom_record" "meshdb_prod_los-backend" {
   answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
 }
 
-resource "namedotcom_record" "meshdb_prod_los" {
+resource "namedotcom_record" "record_los_6530453" {
   domain_name = "nycmesh.net"
   host        = "los.db"
   record_type = "CNAME"

--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -19,7 +19,7 @@ resource "namedotcom_record" "record_wiki_1031824" {
   domain_name = "nycmesh.net"
   host        = "wiki"
   record_type = "CNAME"
-  answer      = "db.mesh.nycmesh.net"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
 }
 
 # SPF (email)
@@ -376,4 +376,83 @@ resource "namedotcom_record" "record__123" {
   domain_name = "nycmesh.net"
   host        = "jamestest"
   record_type = "A"
+}
+
+###### Meshdb Prod ######
+resource "namedotcom_record" "meshdb_prod_k8s_lb" {
+  domain_name = "nycmesh.net"
+  host        = "kubernetes-lb-prod-sn3"
+  record_type = "A"
+  answer      = "199.170.132.45"
+}
+
+resource "namedotcom_record" "meshdb_prod_meshdb" {
+  domain_name = "nycmesh.net"
+  host        = "db"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+}
+
+resource "namedotcom_record" "meshdb_prod_pgadmin" {
+  domain_name = "nycmesh.net"
+  host        = "pgadmin.db"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+}
+
+resource "namedotcom_record" "meshdb_prod_map" {
+  domain_name = "nycmesh.net"
+  host        = "map.db"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+}
+
+resource "namedotcom_record" "meshdb_prod_adminmap" {
+  domain_name = "nycmesh.net"
+  host        = "adminmap.db"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+}
+
+resource "namedotcom_record" "meshdb_prod_los-backend" {
+  domain_name = "nycmesh.net"
+  host        = "los-backend.db"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+}
+
+resource "namedotcom_record" "meshdb_prod_los" {
+  domain_name = "nycmesh.net"
+  host        = "los.db"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+}
+
+resource "namedotcom_record" "meshdb_prod_forms" {
+  domain_name = "nycmesh.net"
+  host        = "forms"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+}
+
+###### Meshdb Dev ######
+resource "namedotcom_record" "meshdb_dev_k8s_lb" {
+  domain_name = "nycmesh.net"
+  host        = "kubernetes-lb-jon-sn3"
+  record_type = "A"
+  answer      = "199.170.132.46"
+}
+
+resource "namedotcom_record" "devdb" {
+  domain_name = "nycmesh.net"
+  host        = "devdb"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-jon-sn3"
+}
+
+resource "namedotcom_record" "devdb_all" {
+  domain_name = "nycmesh.net"
+  host        = "*.devdb"
+  record_type = "CNAME"
+  answer      = "kubernetes-lb-jon-sn3"
 }


### PR DESCRIPTION
This will allow the following to be:

## Prod 
- db.nycmesh.net
- pgadmin.db.nycmesh.net
- map.db.nycmesh.net
- adminmap.db.nycmesh.net
- los-backend.db.nycmesh.net
- los.nycmesh.net
- forms.nycmesh.net

## Dev
- devdb.nycmesh.net
- pgadmin.devdb.nycmesh.net
- map.devdb.nycmesh.net
- adminmap.devdb.nycmesh.net
- los-backend.devdb.nycmesh.net
- los.devdb.nycmesh.net
- forms.devdb.nycmesh.net