### PR TITLE
Remove the 'monitoring' subdomain which appears unused

### DIFF
--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -241,14 +241,6 @@ resource "namedotcom_record" "record_configgen_5386032" {
   answer      = "nycmesh-configgen.netlify.com"
 }
 
-# Offline as of 9/2/24
-resource "namedotcom_record" "record_monitoring_6041298" {
-  domain_name = "nycmesh.net"
-  host        = "monitoring"
-  record_type = "A"
-  answer      = "147.75.67.41"
-}
-
 # Redirects to https://github.com/meshcenter/mesh-api
 resource "namedotcom_record" "record_api_7081451" {
   domain_name = "nycmesh.net"


### PR DESCRIPTION
I have not been able to find any references to `monitoring.nycmesh.net` and it appears to be offline. I'm not familiar with hosting at the address it is pointing to now.

**Please only approve this PR if you can confirm the domain is no longer in use.**