### PR TITLE
CNAME wiki.mesh.nycmesh.net to k8s-lb for redirection after cutover

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -21,7 +21,7 @@ donuts A 10.70.73.29
 unifi A 10.70.90.158
 netbox A 10.70.90.135
 alerts A 10.70.178.21
-wiki A 18.213.129.204
+wiki CNAME grandbox
 mastodon A 199.170.132.101
 gsg-displays A 199.170.132.101
 building A 10.70.187.216

--- a/mesh.zone
+++ b/mesh.zone
@@ -21,7 +21,7 @@ donuts A 10.70.73.29
 unifi A 10.70.90.158
 netbox A 10.70.90.135
 alerts A 10.70.178.21
-wiki CNAME grandbox
+wiki CNAME db
 mastodon A 199.170.132.101
 gsg-displays A 199.170.132.101
 building A 10.70.187.216

--- a/mesh.zone
+++ b/mesh.zone
@@ -21,7 +21,7 @@ donuts A 10.70.73.29
 unifi A 10.70.90.158
 netbox A 10.70.90.135
 alerts A 10.70.178.21
-wiki CNAME db
+wiki CNAME db.nycmesh.net
 mastodon A 199.170.132.101
 gsg-displays A 199.170.132.101
 building A 10.70.187.216


### PR DESCRIPTION
This is one of the steps to [migrate](https://github.com/nycmeshnet/nycmesh.net/pull/157) the wiki from `wiki.mesh.nycmesh.net` to `wiki.nycmesh.net`.

A redirect has already been configured in apache on grandbox to redirect `wiki.mesh.nycmesh.net` to `wiki.nycmesh.net` for those with bookmarks. This will be available for as long as the Let's Encrypt cert is valid.