### PR TITLE
Add A records for soon to be authoritative server

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -10,7 +10,7 @@ $TTL 3600
 ; Allocated domains
 dns   A     10.10.10.10
 ns    A     10.10.10.11
-nycmesh-713-dns-auth-3 A 199.170.132.47
+nycmesh-713-dns-auth-4 A 199.170.132.47
 ebook A     10.70.129.51
 something A 1.1.1.1
 unms	CNAME uisp

--- a/mesh.zone
+++ b/mesh.zone
@@ -10,6 +10,7 @@ $TTL 3600
 ; Allocated domains
 dns   A     10.10.10.10
 ns    A     10.10.10.11
+nycmesh-713-dns-auth-3 A 199.167.59.11
 ebook A     10.70.129.51
 something A 1.1.1.1
 unms	CNAME uisp

--- a/mesh.zone
+++ b/mesh.zone
@@ -10,7 +10,7 @@ $TTL 3600
 ; Allocated domains
 dns   A     10.10.10.10
 ns    A     10.10.10.11
-nycmesh-713-dns-auth-3 A 199.167.59.11
+nycmesh-713-dns-auth-3 A 199.170.132.47
 ebook A     10.70.129.51
 something A 1.1.1.1
 unms	CNAME uisp

--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -226,9 +226,9 @@ resource "namedotcom_record" "record_nycmesh-375p-dns1-authoritative_5233306" {
 }
 
 # Authoritative DNS server for the mesh.nycmesh.net zone at SN3
-resource "namedotcom_record" "nycmesh-713-dns-auth-3" {
+resource "namedotcom_record" "nycmesh-713-dns-auth-4" {
   domain_name = "nycmesh.net"
-  host        = "nycmesh-713-dns-auth-3"
+  host        = "nycmesh-713-dns-auth-4"
   record_type = "A"
   answer      = "199.170.132.47"
 }

--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -225,6 +225,14 @@ resource "namedotcom_record" "record_nycmesh-375p-dns1-authoritative_5233306" {
   answer      = "199.167.59.11"
 }
 
+# Authoritative DNS server for the mesh.nycmesh.net zone at SN3
+resource "namedotcom_record" "nycmesh-713-dns-auth-3" {
+  domain_name = "nycmesh.net"
+  host        = "nycmesh-713-dns-auth-3"
+  record_type = "A"
+  answer      = "199.170.132.47"
+}
+
 # Slack redirect
 resource "namedotcom_record" "record_slack_5235473" {
   domain_name = "nycmesh.net"


### PR DESCRIPTION
This can be merged at any time.

This adds `A` records in the `mesh.nycmesh.net` and `nycmesh.net` zones for an authoritative name server hosted at SN3. This does not cause DNS lookups to flow to that server, there is another PR to do that.