### PR TITLE
Point nycmeshconnect.com to github pages

### DIFF
--- a/sld/records.nycmeshconnect.com.tf
+++ b/sld/records.nycmeshconnect.com.tf
@@ -1,1 +1,30 @@
-# No records exist
+# Pointed to github pages
+# https://github.com/nycmeshnet/connect-redirect
+
+resource "namedotcom_record" "A_108" {
+  domain_name = "nycmeshconnect.com"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.108.153"
+}
+
+resource "namedotcom_record" "A_109" {
+  domain_name = "nycmeshconnect.com"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.109.153"
+}
+
+resource "namedotcom_record" "A_110" {
+  domain_name = "nycmeshconnect.com"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.110.153"
+}
+
+resource "namedotcom_record" "A_111" {
+  domain_name = "nycmeshconnect.com"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.111.153"
+}


### PR DESCRIPTION
This will allow https://github.com/nycmeshnet/connect-redirect to be used to redirect nycmeshconnect.com -> nycmeshconnect.net