### PR TITLE
Add www CNAMEs for nycmeshconnect net + com

### DIFF
--- a/sld/records.nycmeshconnect.com.tf
+++ b/sld/records.nycmeshconnect.com.tf
@@ -28,3 +28,10 @@ resource "namedotcom_record" "A_111" {
   record_type = "A"
   answer      = "185.199.111.153"
 }
+
+resource "namedotcom_record" "nycmeshconnect_com_www_cname" {
+  domain_name = "nycmeshconnect.com"
+  host        = "www"
+  record_type = "CNAME"
+  answer      = "nycmeshnet.github.io"
+}

--- a/sld/records.nycmeshconnect.net.tf
+++ b/sld/records.nycmeshconnect.net.tf
@@ -28,3 +28,10 @@ resource "namedotcom_record" "record__240356250" {
   record_type = "A"
   answer      = "185.199.111.153"
 }
+
+resource "namedotcom_record" "nycmeshconnect_net_www_cname" {
+  domain_name = "nycmeshconnect.net"
+  host        = "www"
+  record_type = "CNAME"
+  answer      = "nycmeshnet.github.io"
+}


### PR DESCRIPTION
@OlivierMorf noticed that at least one of the domains is referenced in official documents using the `www` subdomain and recommended that we add those records so that the links work. `nycmeshconnect.net` and `nycmeshconnect.com` are hosted using GitHub pages, so the new subdomains are pointed there.

Thanks Olivier!