### PR TITLE
Point themesh.nyc to github pages

### DIFF
--- a/sld/records.themesh.nyc.tf
+++ b/sld/records.themesh.nyc.tf
@@ -1,13 +1,36 @@
-resource "namedotcom_record" "record__3336260" {
+# https://github.com/nycmeshnet/themesh.nyc/blob/main/CNAME
+
+resource "namedotcom_record" "themesh_A_108" {
   domain_name = "themesh.nyc"
   host        = ""
   record_type = "A"
-  answer      = "192.241.159.206"
+  answer      = "185.199.108.153"
 }
 
-resource "namedotcom_record" "record__3336261" {
+resource "namedotcom_record" "themesh_A_109" {
   domain_name = "themesh.nyc"
-  host        = "*"
+  host        = ""
   record_type = "A"
-  answer      = "192.241.159.206"
+  answer      = "185.199.109.153"
+}
+
+resource "namedotcom_record" "themesh_A_110" {
+  domain_name = "themesh.nyc"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.110.153"
+}
+
+resource "namedotcom_record" "themesh_A_111" {
+  domain_name = "themesh.nyc"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.111.153"
+}
+
+resource "namedotcom_record" "themesh_nyc_www_cname" {
+  domain_name = "themesh.nyc"
+  host        = "www"
+  record_type = "CNAME"
+  answer      = "nycmeshnet.github.io"
 }


### PR DESCRIPTION
Similar to the recent update for `nycmeshconnect.com` this will allow https://github.com/nycmeshnet/themesh.nyc to be used to redirect `themesh.nyc` -> `nycmesh.net`. This takes care of the apex domain and the `www` subdomain at once.

As far as I can tell, this is currently pointed at Digital Ocean, but it doesn't look like anything is running there.