### PR TITLE
Point themesh.foundation to github pages

### DIFF
--- a/sld/records.themesh.foundation.tf
+++ b/sld/records.themesh.foundation.tf
@@ -1,15 +1,36 @@
-# Parked with sedo.com
+# https://github.com/nycmeshnet/themesh.foundation/blob/main/CNAME
 
-resource "namedotcom_record" "record__4980549" {
+resource "namedotcom_record" "themesh_foundation_A_108" {
   domain_name = "themesh.foundation"
   host        = ""
   record_type = "A"
-  answer      = "75.126.102.240"
+  answer      = "185.199.108.153"
 }
 
-resource "namedotcom_record" "record__4980550" {
+resource "namedotcom_record" "themesh_foundation_A_109" {
   domain_name = "themesh.foundation"
-  host        = "*"
+  host        = ""
   record_type = "A"
-  answer      = "75.126.102.240"
+  answer      = "185.199.109.153"
+}
+
+resource "namedotcom_record" "themesh_foundation_A_110" {
+  domain_name = "themesh.foundation"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.110.153"
+}
+
+resource "namedotcom_record" "themesh_foundation_A_111" {
+  domain_name = "themesh.foundation"
+  host        = ""
+  record_type = "A"
+  answer      = "185.199.111.153"
+}
+
+resource "namedotcom_record" "themesh_foundation_www_cname" {
+  domain_name = "themesh.foundation"
+  host        = "www"
+  record_type = "CNAME"
+  answer      = "nycmeshnet.github.io"
 }


### PR DESCRIPTION
Similar to the recent update for `themesh.nyc` this will allow https://github.com/nycmeshnet/themesh.foundation to be used to redirect `themesh.foundation` -> `nycmesh.net` (now including HTTPS). This takes care of the apex domain and the www subdomain at once.

The domain currently IFRAMEs nycmesh.net and is available via HTTP but not HTTPS.