### PR TITLE
Remove the pgadmin subdomain

### DIFF
--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -385,13 +385,6 @@ resource "namedotcom_record" "meshdb_prod_meshdb" {
   answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
 }
 
-resource "namedotcom_record" "meshdb_prod_pgadmin" {
-  domain_name = "nycmesh.net"
-  host        = "pgadmin.db"
-  record_type = "CNAME"
-  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
-}
-
 resource "namedotcom_record" "meshdb_prod_map" {
   domain_name = "nycmesh.net"
   host        = "map.db"


### PR DESCRIPTION
Soon, the subdomain will no longer be used by MeshDB, so it can be removed. Yes, it is correct that there is only one record removed.

- [ ] Merge https://github.com/nycmeshnet/k8s-infra/pull/30