### PR TITLE
Add NS records for doh.mesh.nycmesh.net

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -86,6 +86,7 @@ wazuh A 10.70.90.75
 jamesprojects A 10.70.90.53
 
 ; doh
+; Temporarily to aws for prototyping, will be a separate zone within the mesh later
 doh NS ns-1726.awsdns-23.co.uk
 doh NS ns-850.awsdns-42.net
 doh NS ns-110.awsdns-13.com

--- a/mesh.zone
+++ b/mesh.zone
@@ -85,6 +85,12 @@ scan A 10.70.90.120
 wazuh A 10.70.90.75
 jamesprojects A 10.70.90.53
 
+; doh
+doh NS ns-1726.awsdns-23.co.uk
+doh NS ns-850.awsdns-42.net
+doh NS ns-110.awsdns-13.com
+doh NS ns-1321.awsdns-37.org
+
 ; Reserved as services are made
 null A 10.10.10.254
 vpn A 10.10.10.254


### PR DESCRIPTION
This PR points the `doh.mesh.nycmesh.net` domain to route53. The `doh` subdomain is to be used to host DoH servers, which need valid SSL certificates. The plan is to use route53 to make domain validation using the DNS-01 challenge type easy when there are multiple nameservers for the mesh zone.