### PR TITLE
Only include the hostname in SOA

### DIFF
--- a/nycmeshconnect.com.zone
+++ b/nycmeshconnect.com.zone
@@ -1,5 +1,5 @@
 $TTL 3600
-@  SOA   ( nycmesh-713-dns-auth-4.nycmeshconnect.com hostmaster.nycmesh.net. 2024101000 1d 2h 4w 1h )
+@  SOA   ( nycmesh-713-dns-auth-4 hostmaster.nycmesh.net. 2024101000 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-4
 
 ; GitHub Pages - https://github.com/nycmeshnet/connect-redirect

--- a/nycmeshconnect.net.zone
+++ b/nycmeshconnect.net.zone
@@ -1,5 +1,5 @@
 $TTL 3600
-@  SOA   ( nycmesh-713-dns-auth-4.nycmeshconnect.net hostmaster.nycmesh.net. 2024101000 1d 2h 4w 1h )
+@  SOA   ( nycmesh-713-dns-auth-4 hostmaster.nycmesh.net. 2024101000 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-4
 
 ; GitHub Pages - https://github.com/nycmeshnet/connect/blob/main/CNAME

--- a/themesh.nyc.zone
+++ b/themesh.nyc.zone
@@ -1,5 +1,5 @@
 $TTL 3600
-@  SOA   ( nycmesh-713-dns-auth-4.themesh.nyc hostmaster.nycmesh.net. 2024101000 1d 2h 4w 1h )
+@  SOA   ( nycmesh-713-dns-auth-4 hostmaster.nycmesh.net. 2024101000 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-4
 
 ; GitHub Pages - https://github.com/nycmeshnet/themesh.nyc/blob/main/CNAME


### PR DESCRIPTION
Right now the SOA records (that are not actually in use) are pointing to subdomains like `nycmesh-713-dns-auth-4.themesh.foundation.themesh.foundation`, instead they should just include the hostname