### PR TITLE
Cleanup meshdb related subdomains from the mesh zone

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -66,16 +66,6 @@ grandbox A 10.69.19.233
 grandsvc A 199.167.59.101
 *.grandsvc CNAME grandsvc
 
-; k8s-infra
-db CNAME grandsvc
-*.db CNAME grandsvc
-forms CNAME grandsvc
-adminmap CNAME grandsvc
-map CNAME grandsvc
-los CNAME grandsvc
-los-backend CNAME grandsvc
-pgadmin CNAME grandsvc
-
 ; k8s-infra dev
 devdb A 199.170.132.46
 devwiki CNAME devdb


### PR DESCRIPTION
These legacy domains are currently pointing at grandsvc for redirection, but are no longer used because the domains moved outside of the mesh zone.

The certs for these domains expire on 12/12/24 and will intentionally not be renewed. Merge this some time after that.