### PR TITLE
Add gh-pages-test.mesh to test use of GH Pages

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -59,6 +59,13 @@ ipmi.petra A 10.70.90.89
 andrew-vpn-endpoint-router A 54.161.165.190
 andrew NS andrew-vpn-endpoint-router
 
+; GH Pages
+gh-pages-test A 185.199.108.153
+gh-pages-test A 185.199.109.153
+gh-pages-test A 185.199.110.153
+gh-pages-test A 185.199.111.153
+_github-pages-challenge-nycmeshnet.gh-pages-test TXT eb245ecc24cba5c7cf81b241c693ff
+
 ; Willard
 zabbix A 10.70.90.40
 status A 164.92.117.225


### PR DESCRIPTION
Testing the use of GH Pages for nycmesh.net, this domain will enable custom domain testing