### PR TITLE
Add kzonecheck to pr build

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,7 +27,7 @@ jobs:
         run: terraform fmt -check
       
       - name: Setup kzonecheck
-        run: sudo apt-get update && sudo apt-get install -y knot-dnsutils
+        run: sudo apt-get update && sudo apt-get install -y knot-dnssecutils
       
       - name: Run kzonecheck on each zone file
-        run: find . -type f -name "*.zone" -print0 | xargs -0L1 kzonecheck
+        run: find . -type f -name "*.zone" -print0 | xargs -0L1 kzonecheck -v

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -6,10 +6,6 @@ on:
 
 permissions: read-all
 
-defaults:
-  run:
-    working-directory: sld
-
 jobs:
   validations:
     name: "Validate"
@@ -25,6 +21,7 @@ jobs:
 
       - name: Terraform format
         run: terraform fmt -check
+        working-directory: sld
       
       - name: Setup kzonecheck
         run: sudo apt-get update && sudo apt-get install -y knot-dnsutils

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,7 +27,7 @@ jobs:
         run: terraform fmt -check
       
       - name: Setup kzonecheck
-        run: apt-get update && apt-get install -y knot-dnsutils
+        run: sudo apt-get update && sudo apt-get install -y knot-dnsutils
       
       - name: Run kzonecheck on each zone file
         run: find . -type f -name "*.zone" -exec kzonecheck {} ';'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,7 +27,7 @@ jobs:
         run: terraform fmt -check
       
       - name: Setup kzonecheck
-        run: sudo apt-get update && sudo apt-get install -y knot-dnssecutils
+        run: sudo apt-get update && sudo apt-get install -y knot-dnsutils
       
       - name: Run kzonecheck on each zone file
         run: find . -type f -name "*.zone" -print0 | xargs -0L1 kzonecheck -v

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,8 +3,6 @@ name: "Pull Request"
 
 on:
   pull_request:
-    paths:
-      - 'sld/**'
 
 permissions: read-all
 
@@ -13,8 +11,8 @@ defaults:
     working-directory: sld
 
 jobs:
-  terraform:
-    name: "Terraform"
+  validations:
+    name: "Validate"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,5 +24,10 @@ jobs:
           terraform_version: 1.8.3
 
       - name: Terraform format
-        id: fmt
         run: terraform fmt -check
+      
+      - name: Setup kzonecheck
+        run: apt-get update && apt-get install -y knot-dnsutils
+      
+      - name: Run kzonecheck on each zone file
+        run: find . -type f -name "*.zone" -exec kzonecheck {} ';'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,4 +30,4 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y knot-dnsutils
       
       - name: Run kzonecheck on each zone file
-        run: find . -type f -name "*.zone" -exec kzonecheck {} ';'
+        run: find . -type f -name "*.zone" -print0 | xargs -0L1 kzonecheck

--- a/mesh.zone
+++ b/mesh.zone
@@ -96,7 +96,7 @@ jmstemp A 199.170.132.45
 doh NS nycmesh-713-dns-auth-4
 
 ; David K
-emergency-dev A 10.70.90.161
+emergency-dev 10.70.90.161
 
 ; Reserved as services are made
 null A 10.10.10.254

--- a/mesh.zone
+++ b/mesh.zone
@@ -96,7 +96,7 @@ jmstemp A 199.170.132.45
 doh NS nycmesh-713-dns-auth-4
 
 ; David K
-emergency-dev  10.70.90.161
+emergency-dev A 10.70.90.161
 
 ; Reserved as services are made
 null A 10.10.10.254

--- a/mesh.zone
+++ b/mesh.zone
@@ -96,7 +96,7 @@ jmstemp A 199.170.132.45
 doh NS nycmesh-713-dns-auth-4
 
 ; David K
-emergency-dev A 10.70.90.161
+emergency-dev  10.70.90.161
 
 ; Reserved as services are made
 null A 10.10.10.254

--- a/mesh.zone
+++ b/mesh.zone
@@ -96,7 +96,7 @@ jmstemp A 199.170.132.45
 doh NS nycmesh-713-dns-auth-4
 
 ; David K
-emergency-dev 10.70.90.161
+emergency-dev A 10.70.90.161
 
 ; Reserved as services are made
 null A 10.10.10.254


### PR DESCRIPTION
> The utility checks  zone file syntax and runs semantic checks on the zone content. The executed checks are the same as the checks run by the Knot DNS server.


[kzonecheck](https://manpages.ubuntu.com/manpages/jammy/man1/kzonecheck.1.html)

The idea here is to catch typos in the zone files at PR time, mostly so that I stop needing to bug people for approvals again after I continue making typos.

Example of it finding an issue: https://github.com/nycmeshnet/nycmesh-dns/actions/runs/11849829711/job/33023716149

Example of no issue: https://github.com/nycmeshnet/nycmesh-dns/actions/runs/11849845206/job/33023749749
