### PR TITLE
Remove the SN1 NS record for the mesh zone

### DIFF
--- a/doh.mesh.nycmesh.net.zone
+++ b/doh.mesh.nycmesh.net.zone
@@ -1,5 +1,5 @@
 $TTL 3600
-@  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024101000 1d 2h 4w 1h )
+@  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 
 ; Authoritative DNS servers

--- a/mesh.zone
+++ b/mesh.zone
@@ -1,6 +1,6 @@
 ; $ORIGIN mesh.
 $TTL 3600
-@  SOA   10.10.10.11. hostmaster.nycmesh.net. ( 2019090700 1d 2h 4w 1h )
+@  SOA   nycmesh-10-dns-auth-5 hostmaster.nycmesh.net. ( 2024120100 1d 2h 4w 1h )
 @  NS    ns
 @  NS    nycmesh-713-dns-auth-3
 @  NS    nycmesh-10-dns-auth-5

--- a/mesh.zone
+++ b/mesh.zone
@@ -1,8 +1,8 @@
 ; $ORIGIN mesh.
 $TTL 3600
-@  SOA   nycmesh-10-dns-auth-5 hostmaster.nycmesh.net. ( 2024120100 1d 2h 4w 1h )
+@  SOA   nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. ( 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
-@  NS    nycmesh-10-dns-auth-5
+;@  NS    nycmesh-10-dns-auth-5
 @  A     10.10.10.11             ; IPv4 address for example.com
 
 @ MX 10 mail

--- a/mesh.zone
+++ b/mesh.zone
@@ -1,7 +1,6 @@
 ; $ORIGIN mesh.
 $TTL 3600
 @  SOA   nycmesh-10-dns-auth-5 hostmaster.nycmesh.net. ( 2024120100 1d 2h 4w 1h )
-@  NS    ns
 @  NS    nycmesh-713-dns-auth-3
 @  NS    nycmesh-10-dns-auth-5
 @  A     10.10.10.11             ; IPv4 address for example.com

--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -222,12 +222,12 @@ resource "namedotcom_record" "nycmesh-10-dns-auth-6" {
 # NS record for the authoritative servers for mesh.nycmesh.net at SN10 + SN3
 # nycmesh-713-dns-auth-4
 # nycmesh-10-dns-auth-5
-resource "namedotcom_record" "mesh_ns_nycmesh-10-dns-auth-5" {
-  domain_name = "nycmesh.net"
-  host        = "mesh"
-  record_type = "NS"
-  answer      = "nycmesh-10-dns-auth-5.nycmesh.net"
-}
+#resource "namedotcom_record" "mesh_ns_nycmesh-10-dns-auth-5" {
+#  domain_name = "nycmesh.net"
+#  host        = "mesh"
+#  record_type = "NS"
+#  answer      = "nycmesh-10-dns-auth-5.nycmesh.net"
+#}
 
 # Authoritative DNS server for the mesh.nycmesh.net zone at SN3
 resource "namedotcom_record" "nycmesh-713-dns-auth-4" {

--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -185,15 +185,7 @@ resource "namedotcom_record" "record_nycmesh-375p-dns1-resolver_5233305" {
   answer      = "199.167.59.10"
 }
 
-# NS record for the authoritative server for mesh.nycmesh.net at SN1
-resource "namedotcom_record" "record_mesh_5226462" {
-  domain_name = "nycmesh.net"
-  host        = "mesh"
-  record_type = "NS"
-  answer      = "nycmesh-375p-dns1-authoritative.nycmesh.net"
-}
-
-# Authoritative DNS server for the mesh.nycmesh.net zone at SN1
+# Former authoritative DNS server for the mesh.nycmesh.net zone at SN1
 resource "namedotcom_record" "record_nycmesh-375p-dns1-authoritative_5233306" {
   domain_name = "nycmesh.net"
   host        = "nycmesh-375p-dns1-authoritative"

--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -385,7 +385,7 @@ resource "namedotcom_record" "k8s_stateless_services_prod" {
   domain_name = "nycmesh.net"
   host        = "k8s-stateless-prod"
   record_type = "CNAME"
-  answer      = "kubernetes-lb-prod-sn10.nycmesh.net"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
 }
 
 resource "namedotcom_record" "k8s_stateless_services_dev" {


### PR DESCRIPTION
Also contains the changes from https://github.com/nycmeshnet/nycmesh-dns/pull/151

This makes it so DNS requests for *.mesh.nycmesh.net go only to the new servers at SN10 and SN3 and not the server(s) at SN1.

Also, fail over stateless services to SN3.

**Do not merge until instructed.**