### PR TITLE
Point stub resolvers away from 10.10.10.11

### DIFF
--- a/infra/terraform/dev_jon.tfvars
+++ b/infra/terraform/dev_jon.tfvars
@@ -36,3 +36,4 @@ recursive_cores                 = 4
 recursive_sockets               = 1
 recursive_memory                = 4096
 enable_doh                      = ""
+mesh_stub_resolver              = "23.158.16.23"

--- a/infra/terraform/prod_sn10.tfvars
+++ b/infra/terraform/prod_sn10.tfvars
@@ -46,3 +46,4 @@ recursive_cores                 = 5
 recursive_sockets               = 1
 recursive_memory                = 4096
 enable_doh                      = "enable"
+mesh_stub_resolver              = "199.170.132.47"

--- a/infra/terraform/prod_sn3.tfvars
+++ b/infra/terraform/prod_sn3.tfvars
@@ -46,3 +46,4 @@ recursive_cores                 = 5
 recursive_sockets               = 1
 recursive_memory                = 4096
 enable_doh                      = "enable"
+mesh_stub_resolver              = "23.158.16.23"


### PR DESCRIPTION
Point the stub resolvers at the opposite SN's authoritative DNS server IP, which is also on the secondary server at the same SN.

This means that when 10.10.10.10 gets a query for wiki.mesh or wiki.mesh.nycmesh.net, it makes a query to the secondary server (which has less load) at the same SN. If there is no route to the secondary server at the same SN, the query will cross the mesh to the primary server with that IP at the other SN.