### PR TITLE
Add the beta ip to jon

### DIFF
--- a/infra/terraform/dev_jon.tfvars
+++ b/infra/terraform/dev_jon.tfvars
@@ -16,7 +16,7 @@ dns_auth_internal_ip = [
   "10.70.90.136",
 ]
 dns_rec_internal_ip = [
-  "10.70.90.137",
+  "10.70.90.133",
 ]
 dns_auth_external_ip = [
   "199.170.132.48",


### PR DESCRIPTION
This will make the beta IP available at jon, in addition to the other 2 locations (until it is removed from the other 2 locations).