### PR TITLE
Use 10.10.10.11 instead of the beta IP

### DIFF
--- a/infra/terraform/prod_sn10.tfvars
+++ b/infra/terraform/prod_sn10.tfvars
@@ -23,7 +23,7 @@ dns_auth_internal_ip = [
 ]
 dns_rec_internal_ip = [
   "10.10.10.10",
-  "10.70.90.133",
+  "10.10.10.11",
 ]
 dns_auth_external_ip = [
   "23.158.16.23",

--- a/infra/terraform/prod_sn3.tfvars
+++ b/infra/terraform/prod_sn3.tfvars
@@ -23,7 +23,7 @@ dns_auth_internal_ip = [
 ]
 dns_rec_internal_ip = [
   "10.10.10.10",
-  "10.70.90.133",
+  "10.10.10.11",
 ]
 dns_auth_external_ip = [
   "199.170.132.47",

--- a/makereverse.py
+++ b/makereverse.py
@@ -10,10 +10,12 @@ output = { r: [] for r in validreverse }
 
 header = """$ORIGIN {}
 $TTL 3600
-@  SOA   10.10.10.11. noc.nycmesh.net. ( 2018042700 1d 2h 4w 1h )
-@  NS    ns
+@  SOA   nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. ( 2024120100 1d 2h 4w 1h )
+@  NS    nycmesh-713-dns-auth-3
+@  NS    nycmesh-10-dns-auth-5
 @  A     10.10.10.11
-ns A     10.10.10.11
+nycmesh-10-dns-auth-5 A 23.158.16.23
+nycmesh-713-dns-auth-3 A 199.170.132.47
 """
 
 def inaddrarpa(x):


### PR DESCRIPTION
This adds new servers to perform "normal" DNS resolution at 10.10.10.11 alongside 10.10.10.10 to maintain compatibility with the current state of things.

You can confirm the current behavior of 10.10.10.11 via: `dig mikrotik.com @10.10.10.11` notice that resolution is successful. This behavior is different than making the same query to an authoritative server (operated by us not mikrotik) where recursion is disabled `dig mikrotik.com @23.158.16.23` which will correctly fail.

Only merge after:
- [x] https://github.com/nycmeshnet/nycmesh-dns/pull/168
- [x] https://github.com/nycmeshnet/nycmesh-dns/pull/169
- [x] https://github.com/nycmeshnet/nycmesh-dns/pull/187
- [x] Make sure delegated subdomains work as expected