### PR TITLE
Remove ebook record

### DIFF
--- a/mesh.zone
+++ b/mesh.zone
@@ -14,7 +14,6 @@ ns    A     10.10.10.11
 nycmesh-10-dns-auth-5 A 23.158.16.23
 nycmesh-713-dns-auth-3 A 199.170.132.47
 nycmesh-713-jon-dns-auth-1 A 199.170.132.48
-ebook A     10.70.129.51
 something A 1.1.1.1
 unms	CNAME uisp
 uisp	A 10.70.76.21


### PR DESCRIPTION
This record points to an IP being used by a server I operate. I do not need the record to point to the server I am operating and therefore it can be removed.