### PR TITLE
Send stateless services to SN3

### DIFF
--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -377,7 +377,7 @@ resource "namedotcom_record" "k8s_stateless_services_prod" {
   domain_name = "nycmesh.net"
   host        = "k8s-stateless-prod"
   record_type = "CNAME"
-  answer      = "kubernetes-lb-prod-sn10.nycmesh.net"
+  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
 }
 
 resource "namedotcom_record" "k8s_stateless_services_dev" {


### PR DESCRIPTION
This is to avoid the <60 second downtime when switching from frr to bird

For: https://github.com/nycmeshnet/k8s-infra/pull/73

**DO NOT MERGE**