### PR TITLE
Back to SN10

### DIFF
--- a/sld/records.nycmesh.net.tf
+++ b/sld/records.nycmesh.net.tf
@@ -222,12 +222,12 @@ resource "namedotcom_record" "nycmesh-10-dns-auth-6" {
 # NS record for the authoritative servers for mesh.nycmesh.net at SN10 + SN3
 # nycmesh-713-dns-auth-4
 # nycmesh-10-dns-auth-5
-#resource "namedotcom_record" "mesh_ns_nycmesh-10-dns-auth-5" {
-#  domain_name = "nycmesh.net"
-#  host        = "mesh"
-#  record_type = "NS"
-#  answer      = "nycmesh-10-dns-auth-5.nycmesh.net"
-#}
+resource "namedotcom_record" "mesh_ns_nycmesh-10-dns-auth-5" {
+  domain_name = "nycmesh.net"
+  host        = "mesh"
+  record_type = "NS"
+  answer      = "nycmesh-10-dns-auth-5.nycmesh.net"
+}
 
 # Authoritative DNS server for the mesh.nycmesh.net zone at SN3
 resource "namedotcom_record" "nycmesh-713-dns-auth-4" {
@@ -377,7 +377,7 @@ resource "namedotcom_record" "k8s_stateless_services_prod" {
   domain_name = "nycmesh.net"
   host        = "k8s-stateless-prod"
   record_type = "CNAME"
-  answer      = "kubernetes-lb-prod-sn3.nycmesh.net"
+  answer      = "kubernetes-lb-prod-sn10.nycmesh.net"
 }
 
 resource "namedotcom_record" "k8s_stateless_services_dev" {


### PR DESCRIPTION
Move stateless services and the auth NS record back to SN10 after the outage