### PR TITLE
Allow writes by knot

### DIFF
--- a/deploy_knot.sh
+++ b/deploy_knot.sh
@@ -16,6 +16,7 @@ fi
 
 python3 generate_nn.py
 python3 makereverse.py
+chown root:knot *.zone
 cp -f *.zone /var/lib/knot/zones
 
 systemctl restart knot

--- a/infra/ansible/roles/knot_authoritative/tasks/main.yaml
+++ b/infra/ansible/roles/knot_authoritative/tasks/main.yaml
@@ -61,7 +61,7 @@
     state: directory
     owner: root
     group: knot
-    mode: "750"
+    mode: "760"
 
 - name: Git checkout
   ansible.builtin.git:


### PR DESCRIPTION
Not allowing writes by group (`knot`) means the zone can't be flushed, which breaks dynamic updates.