### PR TITLE
Set ttl to 300

### DIFF
--- a/airflow.mesh.nycmesh.net.zone
+++ b/airflow.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 

--- a/building-dev.mesh.nycmesh.net.zone
+++ b/building-dev.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 

--- a/building.mesh.nycmesh.net.zone
+++ b/building.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 

--- a/devairflow.mesh.nycmesh.net.zone
+++ b/devairflow.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 

--- a/doh.mesh.nycmesh.net.zone
+++ b/doh.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 

--- a/generate_nn.py
+++ b/generate_nn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-header = """$TTL 3600
+header = """$TTL 300
 @  SOA   nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. ( 2025052100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 

--- a/ha.mesh.nycmesh.net.zone
+++ b/ha.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 

--- a/jamesinternalprodtwo.mesh.nycmesh.net.zone
+++ b/jamesinternalprodtwo.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-10-dns-auth-5 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-10-dns-auth-5
 

--- a/prox.mesh.nycmesh.net.zone
+++ b/prox.mesh.nycmesh.net.zone
@@ -1,4 +1,4 @@
-$TTL 3600
+$TTL 300
 @  SOA   ( nycmesh-713-dns-auth-3 hostmaster.nycmesh.net. 2024120100 1d 2h 4w 1h )
 @  NS    nycmesh-713-dns-auth-3
 


### PR DESCRIPTION
Set the TTL to `300` (5 minutes) instead of `3600` (1 hour) on the zones that are set up to be used for getting certs via Let's Encrypt's DNS-01 challenge to try to force rechecking more often.