### PR TITLE
update namedotcom plugin to 4.1

### DIFF
--- a/sld/provider.tf
+++ b/sld/provider.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     namedotcom = {
       source  = "lexfrei/namedotcom"
-      version = "1.3.1"
+      version = "4.1"
     }
   }
 }


### PR DESCRIPTION
Apparently this was a bug in version 1.3.1, which we've been running for... a while.

https://github.com/lexfrei/terraform-provider-namedotcom/issues/144

Naively going to try updating to 4.1